### PR TITLE
Update packages and allow AC display control #6

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,10 @@
 -------------------------------------------------------------
+Next version
+
+- Allow an ACDevice's display to be turned on and off
+- Upgrade packages
+
+-------------------------------------------------------------
 v0.2.2
 
 - Upgrade packages

--- a/homecontrol_base/aircon/state.py
+++ b/homecontrol_base/aircon/state.py
@@ -61,11 +61,11 @@ class ACDeviceState:
     eco_mode: bool
     turbo_mode: bool
     fahrenheit: bool
+    display_on: bool
 
     # Read only
     indoor_temperature: float
     outdoor_temperature: float
-    display_on: bool
 
     # Write only
     prompt_tone: bool

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-alembic==1.13.1
+alembic==1.13.2
 annotated-types==0.7.0
 anyio==4.4.0
 broadlink==0.19.0
-certifi==2024.6.2
+certifi==2024.7.4
 cffi==1.16.0
 charset-normalizer==3.3.2
 cryptography==42.0.8
@@ -14,11 +14,11 @@ idna==3.7
 ifaddr==0.2.0
 Mako==1.3.5
 MarkupSafe==2.1.5
-msmart-ng==2024.5.4
+msmart-ng==2024.7.0
 pycparser==2.22
 pycryptodome==3.20.0
-pydantic==2.7.4
-pydantic_core==2.18.4
+pydantic==2.8.2
+pydantic_core==2.20.1
 requests==2.32.3
 sniffio==1.3.1
 SQLAlchemy==2.0.31

--- a/test.py
+++ b/test.py
@@ -140,11 +140,11 @@ from homecontrol_base.hue.bridge import HueBridge
 # )
 # device = broadlink_manager.get_device("d8d759d1-0e53-4aee-b9d1-9d172cf3c08e")
 
-with create_homecontrol_base_service() as service:
-    bridge = service.hue.get_bridge_by_name("Home")
+# with create_homecontrol_base_service() as service:
+#     bridge = service.hue.get_bridge_by_name("Home")
 
-    with bridge.connect_api() as conn:
-        lights = conn.get_lights()
+#     with bridge.connect_api() as conn:
+#         lights = conn.get_lights()
 #         for light in lights:
 #             if light.on.on:
 #                 print(light.id)
@@ -215,15 +215,16 @@ with create_homecontrol_base_service() as service:
 #         print(conn.get_rooms())
 
 
-# async def test():
-#     with create_homecontrol_base_service() as service:
-#         await service.aircon.get_device("d257751b-996a-4cc9-8009-a32bd38857dd")
-#         await service.aircon.get_device("d257751b-996a-4cc9-8009-a32bd38857dd")
-#         await service.aircon.get_device("d257751b-996a-4cc9-8009-a32bd38857dd")
-#         print(len(service._ac_manager._devices))
+async def test():
+    with create_homecontrol_base_service() as service:
+        device = await service.aircon.get_device_by_name("Games Room")
+        state = await device.get_state()
+        # state.power = True
+        state.display_on = True
+        await device.set_state(state)
 
 
-# run_until_complete(test)
+run_until_complete(test)
 
 # with create_homecontrol_base_service() as service:
 #     bridge = service.hue.get_bridge("1e9ffff0-960b-4dd9-8372-a16b6df69d0e")


### PR DESCRIPTION
Allows the `display_on` state to be modified and applied for AC devices so their display can be turned on and off. (Will output a `Device is not capable of display control.` warning from msmart-ng if it is not supported)

Closes #6 